### PR TITLE
include headers in Strava::Errors::Fault response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Automatically convert `before` and `after` arguments of `Strava::Api::Client#athlete_activities` from `Time` to `Integer` - [@dblock](https://github.com/dblock).
 * [#18](https://github.com/dblock/strava-ruby-client/pull/18): Testing against Ruby 2.5.3 and 2.6.0 - [@lucianosousa](https://github.com/lucianosousa).
 * [#18](https://github.com/dblock/strava-ruby-client/pull/18): Upgraded Rubocop to 0.61.1 - [@lucianosousa](https://github.com/lucianosousa).
+* [#20](https://github.com/dblock/strava-ruby-client/pull/20): Include headers in error response - [@jameschevalier](https://github.com/jameschevalier).
 * Your contribution here.
 
 ### 0.3.1 (2018/12/05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Automatically convert `before` and `after` arguments of `Strava::Api::Client#athlete_activities` from `Time` to `Integer` - [@dblock](https://github.com/dblock).
 * [#18](https://github.com/dblock/strava-ruby-client/pull/18): Testing against Ruby 2.5.3 and 2.6.0 - [@lucianosousa](https://github.com/lucianosousa).
 * [#18](https://github.com/dblock/strava-ruby-client/pull/18): Upgraded Rubocop to 0.61.1 - [@lucianosousa](https://github.com/lucianosousa).
-* [#20](https://github.com/dblock/strava-ruby-client/pull/20): Include headers in error response - [@jameschevalier](https://github.com/jameschevalier).
+* [#21](https://github.com/dblock/strava-ruby-client/pull/21): Include headers in error response - [@jameschevalier](https://github.com/jameschevalier).
 * Your contribution here.
 
 ### 0.3.1 (2018/12/05)

--- a/README.md
+++ b/README.md
@@ -1037,6 +1037,7 @@ begin
 rescue Strava::Errors::Fault => e
   e.message # => Bad Request
   e.errors # => [{ 'code' => 'invalid', 'field' => 'code', 'resource' => 'RequestToken' }]
+  e.headers # => { "status" => "403 Bad Request", "x-ratelimit-limit" => "600,30000", "x-ratelimit-usage" => "314,27536" }
 end
 ```
 

--- a/lib/strava/errors/fault.rb
+++ b/lib/strava/errors/fault.rb
@@ -5,6 +5,10 @@ module Strava
         response[:body]['message'] || super
       end
 
+      def headers
+        response[:headers]
+      end
+
       def errors
         response[:body]['errors']
       end

--- a/spec/strava/oauth/client_spec.rb
+++ b/spec/strava/oauth/client_spec.rb
@@ -78,38 +78,38 @@ RSpec.describe Strava::OAuth::Client do
       it 'errors with an invalid client id', vcr: { cassette_name: 'oauth/token_invalid_client' } do
         expect { client.oauth_token(code: 'code') }.to raise_error Strava::Errors::Fault do |e|
           expect(e.message).to eq 'Bad Request'
-          expect(e.headers).to eq({
-            "cache-control" => "no-cache",
-            "connection" => "keep-alive",
-            "content-type" => "application/json; charset=UTF-8",
-            "date" => "Thu, 22 Nov 2018 20:16:41 GMT",
-            "status" => "400 Bad Request",
-            "transfer-encoding" => "chunked",
-            "via" => "1.1 linkerd",
-            "x-content-type-options" => "nosniff",
-            "x-frame-options" => "SAMEORIGIN,DENY",
-            "x-request-id" => "168ffeae-9029-4aec-bd50-3a0430e594bd",
-            "x-xss-protection" => "1; mode=block"
-          })
+          expect(e.headers).to eq(
+            'cache-control' => 'no-cache',
+            'connection' => 'keep-alive',
+            'content-type' => 'application/json; charset=UTF-8',
+            'date' => 'Thu, 22 Nov 2018 20:16:41 GMT',
+            'status' => '400 Bad Request',
+            'transfer-encoding' => 'chunked',
+            'via' => '1.1 linkerd',
+            'x-content-type-options' => 'nosniff',
+            'x-frame-options' => 'SAMEORIGIN,DENY',
+            'x-request-id' => '168ffeae-9029-4aec-bd50-3a0430e594bd',
+            'x-xss-protection' => '1; mode=block'
+          )
           expect(e.errors).to eq([{ 'code' => 'invalid', 'field' => 'client_id', 'resource' => 'Application' }])
         end
       end
       it 'errors with an invalid code', vcr: { cassette_name: 'oauth/token_invalid_code' } do
         expect { client.oauth_token(code: 'code') }.to raise_error Faraday::ClientError do |e|
           expect(e.message).to eq 'Bad Request'
-          expect(e.headers).to eq({
-            "cache-control" => "no-cache",
-            "connection" => "keep-alive",
-            "content-type" => "application/json; charset=UTF-8",
-            "date" => "Thu, 22 Nov 2018 20:26:56 GMT",
-            "status" => "400 Bad Request",
-            "transfer-encoding" => "chunked",
-            "via" => "1.1 linkerd",
-            "x-content-type-options" => "nosniff",
-            "x-frame-options" => "SAMEORIGIN,DENY",
-            "x-request-id" => "d3406a4e-9099-400f-b709-aad0ea2768fe",
-            "x-xss-protection" => "1; mode=block"
-          })
+          expect(e.headers).to eq(
+            'cache-control' => 'no-cache',
+            'connection' => 'keep-alive',
+            'content-type' => 'application/json; charset=UTF-8',
+            'date' => 'Thu, 22 Nov 2018 20:26:56 GMT',
+            'status' => '400 Bad Request',
+            'transfer-encoding' => 'chunked',
+            'via' => '1.1 linkerd',
+            'x-content-type-options' => 'nosniff',
+            'x-frame-options' => 'SAMEORIGIN,DENY',
+            'x-request-id' => 'd3406a4e-9099-400f-b709-aad0ea2768fe',
+            'x-xss-protection' => '1; mode=block'
+          )
           expect(e.errors).to eq([{ 'code' => 'invalid', 'field' => 'code', 'resource' => 'RequestToken' }])
         end
       end

--- a/spec/strava/oauth/client_spec.rb
+++ b/spec/strava/oauth/client_spec.rb
@@ -78,12 +78,38 @@ RSpec.describe Strava::OAuth::Client do
       it 'errors with an invalid client id', vcr: { cassette_name: 'oauth/token_invalid_client' } do
         expect { client.oauth_token(code: 'code') }.to raise_error Strava::Errors::Fault do |e|
           expect(e.message).to eq 'Bad Request'
+          expect(e.headers).to eq({
+            "cache-control" => "no-cache",
+            "connection" => "keep-alive",
+            "content-type" => "application/json; charset=UTF-8",
+            "date" => "Thu, 22 Nov 2018 20:16:41 GMT",
+            "status" => "400 Bad Request",
+            "transfer-encoding" => "chunked",
+            "via" => "1.1 linkerd",
+            "x-content-type-options" => "nosniff",
+            "x-frame-options" => "SAMEORIGIN,DENY",
+            "x-request-id" => "168ffeae-9029-4aec-bd50-3a0430e594bd",
+            "x-xss-protection" => "1; mode=block"
+          })
           expect(e.errors).to eq([{ 'code' => 'invalid', 'field' => 'client_id', 'resource' => 'Application' }])
         end
       end
       it 'errors with an invalid code', vcr: { cassette_name: 'oauth/token_invalid_code' } do
         expect { client.oauth_token(code: 'code') }.to raise_error Faraday::ClientError do |e|
           expect(e.message).to eq 'Bad Request'
+          expect(e.headers).to eq({
+            "cache-control" => "no-cache",
+            "connection" => "keep-alive",
+            "content-type" => "application/json; charset=UTF-8",
+            "date" => "Thu, 22 Nov 2018 20:26:56 GMT",
+            "status" => "400 Bad Request",
+            "transfer-encoding" => "chunked",
+            "via" => "1.1 linkerd",
+            "x-content-type-options" => "nosniff",
+            "x-frame-options" => "SAMEORIGIN,DENY",
+            "x-request-id" => "d3406a4e-9099-400f-b709-aad0ea2768fe",
+            "x-xss-protection" => "1; mode=block"
+          })
           expect(e.errors).to eq([{ 'code' => 'invalid', 'field' => 'code', 'resource' => 'RequestToken' }])
         end
       end


### PR DESCRIPTION
Why:
* by including the headers, we have access to `x-ratelimit-limit` and `x-ratelimit-usage`

How:
* pass along the headers, similar to `message` and `errors`
* include the headers (as they exist in the current cassette) in the existing specs
* update the `CHANGELOG.md` file, as requested
* update the `README.md` file to include the existence of `e.headers`, and include a truncated example of its value

Relevant Links:
* https://github.com/dblock/strava-ruby-client/issues/11
* https://developers.strava.com/docs/#rate-limiting