### PR TITLE
Add missing activity:read scope from strava-oauth-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.4.3 (Next)
 
+* [#46](https://github.com/dblock/strava-ruby-client/pull/46): Add missing activity:read scope from strava-oauth-token - [@xaviershay](https://github.com/xaviershay).
 * Your contribution here.
 
 ### 0.4.2 (2021/10/03)

--- a/bin/strava-oauth-token
+++ b/bin/strava-oauth-token
@@ -38,7 +38,7 @@ end
 redirect_url = client.authorize_url(
   redirect_uri: 'http://localhost:4242/',
   response_type: 'code',
-  scope: 'read_all,activity:read_all,profile:read_all,profile:write,activity:write'
+  scope: 'read_all,activity_read,activity:read_all,profile:read_all,profile:write,activity:write'
 )
 
 server.logger.info "opening browser at #{redirect_url}\n"


### PR DESCRIPTION
This allows client to "read the user's activity data for activities that are visible to Everyone and Followers, excluding privacy zone data"

As documented here: https://developers.strava.com/docs/authentication/#detailsaboutrequestingaccess