### PR TITLE
fixes DangerBot warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#23](https://github.com/dblock/strava-ruby-client/pull/23): Failed uploads raise Strava::Errors::UploadError - [@ylecuyer](https://github.com/ylecuyer), [@simonneutert](https://github.com/simonneutert).
 * [#69](https://github.com/dblock/strava-ruby-client/pull/69): Raises `Strava::Api::RatelimitError`, when API ratelimit exceeded - [@simonneutert](https://github.com/simonneutert).
 * [#74](https://github.com/dblock/strava-ruby-client/pull/74): Fixes serialization causing `stack level too deep` - [@simonneutert](https://github.com/simonneutert).
+* [#75](https://github.com/dblock/strava-ruby-client/pull/75): Fixes DangerBot deprecation warning for `check` of TOC - [@simonneutert](https://github.com/simonneutert).
 * Your contribution here.
 
 ### 1.0.0 (2022/12/29)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-toc.check
+toc.check!
 changelog.check


### PR DESCRIPTION
uses `check!` instead of deprecated `check` for DangerBot's TOC check