### PR TITLE
Bump Strava version to 2.3.0 and enhance club events spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 2.2.1 (Next)
+### 2.3.0 (Next)
 
+* [#87](https://github.com/dblock/strava-ruby-client/pull/87): Prepares v2.3.0 by improving the event specs - [@simonneutert](https://github.com/simonneutert).
 * [#86](https://github.com/dblock/strava-ruby-client/pull/86): Add description to club event model - [@tobiaszwaszak](https://github.com/tobiaszwaszak).
 * Your contribution here.
 

--- a/lib/strava/version.rb
+++ b/lib/strava/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Strava
-  VERSION = '2.2.1'
+  VERSION = '2.3.0'
 end

--- a/spec/strava/api/client/endpoints/clubs/club_events_spec.rb
+++ b/spec/strava/api/client/endpoints/clubs/club_events_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Strava::Api::Client#club_events', vcr: { cassette_name: 'client/
     expect(event.private).to be_a FalseClass
     expect(event.description).to be_a String
     expect(event.description.size).to eq(546)
-    expect(event.description.split.take(5).join(' ')).to eq('Damit die Fahrt stattfindet wird')
+    expect(event.description).to start_with('Damit die Fahrt stattfindet wird')
     expect(event.resource_state).to be_a Integer
     expect(event.resource_state).to eq(2)
     expect(event.club_id).to be_a Integer

--- a/spec/strava/api/client/endpoints/clubs/club_events_spec.rb
+++ b/spec/strava/api/client/endpoints/clubs/club_events_spec.rb
@@ -6,19 +6,27 @@ RSpec.describe 'Strava::Api::Client#club_events', vcr: { cassette_name: 'client/
   include_context 'with API client'
   it 'returns club events' do
     club_events = client.club_events('456773')
-    expect(club_events.size).to eq 107
     expect(club_events).to be_a Enumerable
-    event = club_events.first
+    expect(club_events.size).to eq 107
+    event = club_events.find { |e| e.id == 340_487 }
+    expect(event.id).to be_a Integer
+    expect(event.id).to eq(340_487)
     expect(event.women_only).to be_a FalseClass
     expect(event.private).to be_a FalseClass
     expect(event.description).to be_a String
+    expect(event.description.size).to eq(546)
+    expect(event.description.split.take(5).join(' ')).to eq('Damit die Fahrt stattfindet wird')
     expect(event.resource_state).to be_a Integer
+    expect(event.resource_state).to eq(2)
     expect(event.club_id).to be_a Integer
+    expect(event.club_id).to eq(456_773)
     expect(event.skill_levels).to be_a Integer
+    expect(event.skill_levels).to eq(1)
     expect(event.terrain).to be_a Integer
     expect(event.route_id).to be_a(Integer).or(be_nil)
     expect(event.upcoming_occurrences).to be_a Enumerable
     expect(event.upcoming_occurrences.first).to be_a Time
+    expect(event.upcoming_occurrences.first).to eq(Time.new(2018, 6, 23, 8, 30, 0, '+00:00'))
     expect(event).to be_a Strava::Models::ClubEvent
   end
 end


### PR DESCRIPTION
This pull request includes a version update and enhancements to the club events test in the Strava API client.

Version update:

* [`lib/strava/version.rb`](diffhunk://#diff-45df327184ecc04d0549a61369227d024f29713e71ac59968bc2aeb186ed0737L4-R4): Updated the `VERSION` constant from '2.2.1' to '2.3.0'.

Enhancements to club events test:

* [`spec/strava/api/client/endpoints/clubs/club_events_spec.rb`](diffhunk://#diff-39217a5076fab3a3cc20950ed0115bca65e673d394d260e387ff921d9e0e97f4L9-R29): Enhanced the club events test by adding more detailed assertions, including checks for event ID, description size, specific description content, resource state, club ID, skill levels, and upcoming occurrences.…onal assertions