### PR TITLE
Update API base URL and add oauth/revoke per Strava developer program changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#100](https://github.com/dblock/strava-ruby-client/pull/100): Adds comprehensive rdoc documentation - [@dblock](https://github.com/dblock).
 * [#103](https://github.com/dblock/strava-ruby-client/pull/103): Migrate Danger to use the `danger-pr-comment` reusable workflow - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * [#104](https://github.com/dblock/strava-ruby-client/pull/104): Fixes `Danger Comment` workflow failing with a `contents: none` permissions error - [@dblock](https://github.com/dblock).
+* [#102](https://github.com/dblock/strava-ruby-client/pull/102): Changes default API base URL to `https://www.api-v3.strava.com` and adds `revoke`, deprecating `deauthorize`, per Strava's June 2026/2027 developer program changes - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.0.0 (2025/10/24)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Unlike other clients, including [strava-api-v3](https://github.com/jaredholdcrof
   - [Pagination](#pagination)
   - [OAuth](#oauth)
     - [OAuth Workflow](#oauth-workflow)
+    - [Revoke](#revoke)
     - [Deauthorize](#deauthorize)
     - [Command Line OAuth Workflow](#command-line-oauth-workflow)
   - [Webhooks](#webhooks)
@@ -871,6 +872,16 @@ response.refresh_token # => String, new refresh token
 response.expires_at # => Time, new timestamp when the access token expires
 ```
 
+#### Revoke
+
+Revoke access to an athlete's data using an instance of `Strava::API::Client`.
+
+```ruby
+authorization = client.revoke
+
+authorization.access_token # => String, access token being revoked
+```
+
 #### Deauthorize
 
 Revoke access to an athlete's data using an instance of `Strava::API::Client`.
@@ -880,6 +891,8 @@ authorization = client.deauthorize
 
 authorization.access_token # => String, access token being revoked
 ```
+
+_Deprecated: use [`revoke`](#revoke) instead. The `oauth/deauthorize` endpoint will be retired on June 1, 2027 in favor of `oauth/revoke`._
 
 #### Command Line OAuth Workflow
 
@@ -1068,7 +1081,7 @@ The following settings are supported.
 | setting      | description                                         |
 | ------------ | --------------------------------------------------- |
 | access_token | Access token to pass in the `Authorization` header. |
-| endpoint     | Defaults to `https://www.strava.com/api/v3`.        |
+| endpoint     | Defaults to `https://www.api-v3.strava.com`.        |
 
 ### OAuth Client Options
 
@@ -1122,7 +1135,7 @@ The following settings are supported.
 | ------------- | -------------------------------------------- |
 | client_id     | Application client ID.                       |
 | client_secret | Application client secret.                   |
-| endpoint      | Defaults to `https://www.strava.com/api/v3`. |
+| endpoint      | Defaults to `https://www.api-v3.strava.com`. |
 
 ## Errors
 

--- a/lib/strava/api/client.rb
+++ b/lib/strava/api/client.rb
@@ -48,7 +48,7 @@ module Strava
       #
       # @param [Hash] options Configuration options for the client
       # @option options [String] :access_token OAuth access token for API authentication (required)
-      # @option options [String] :endpoint API endpoint URL (defaults to https://www.strava.com/api/v3)
+      # @option options [String] :endpoint API endpoint URL (defaults to https://www.api-v3.strava.com)
       # @option options [String] :user_agent User agent string for HTTP requests
       # @option options [Logger] :logger Logger instance for request/response logging
       # @option options [Integer] :timeout HTTP request timeout in seconds

--- a/lib/strava/api/config.rb
+++ b/lib/strava/api/config.rb
@@ -15,7 +15,7 @@ module Strava
     #
     # @example Access current configuration
     #   Strava::Api.config.endpoint
-    #   # => 'https://www.strava.com/api/v3'
+    #   # => 'https://www.api-v3.strava.com'
     #
     module Config
       extend self
@@ -37,7 +37,7 @@ module Strava
       # @return [void]
       #
       def reset
-        self.endpoint = 'https://www.strava.com/api/v3'
+        self.endpoint = 'https://www.api-v3.strava.com'
         self.access_token = nil
       end
     end

--- a/lib/strava/api/endpoints/oauth.rb
+++ b/lib/strava/api/endpoints/oauth.rb
@@ -16,6 +16,26 @@ module Strava
         #
         # Revoke access to an athlete's data.
         #
+        # Revokes the athlete's access token. After calling this method, the
+        # access token will no longer be valid and the athlete will need to
+        # reauthorize the application.
+        #
+        # @param options [Hash] Additional options for the revocation request
+        #
+        # @return [Authorization] Authorization response with revocation confirmation
+        #
+        # @example Revoke access for the current athlete
+        #   client.revoke
+        #
+        # @see https://developers.strava.com/docs/authentication/#deauthorization
+        #
+        def revoke(options = {})
+          Strava::Models::Authorization.new(post('revoke', { endpoint: Strava::OAuth.config.endpoint }.merge(options)))
+        end
+
+        #
+        # Revoke access to an athlete's data.
+        #
         # Deauthorizes the application and revokes the athlete's access token.
         # After calling this method, the access token will no longer be valid
         # and the athlete will need to reauthorize the application.
@@ -26,6 +46,9 @@ module Strava
         #
         # @example Deauthorize the current athlete
         #   client.deauthorize
+        #
+        # @deprecated Use {#revoke} instead. The `oauth/deauthorize` endpoint will
+        #   be retired on June 1, 2027 in favor of the new `oauth/revoke` endpoint.
         #
         # @see https://developers.strava.com/docs/authentication/#deauthorization
         #

--- a/lib/strava/web/client.rb
+++ b/lib/strava/web/client.rb
@@ -58,7 +58,7 @@ module Strava
         #
         # @example Configure the client
         #   Strava::Web::Client.configure do |config|
-        #     config.endpoint = 'https://www.strava.com/api/v3'
+        #     config.endpoint = 'https://www.api-v3.strava.com'
         #   end
         #
         def configure

--- a/lib/strava/webhooks/client.rb
+++ b/lib/strava/webhooks/client.rb
@@ -43,7 +43,7 @@ module Strava
       # @param [Hash] options Configuration options
       # @option options [String] :client_id Strava application client ID (required)
       # @option options [String] :client_secret Strava application client secret (required)
-      # @option options [String] :endpoint API endpoint URL (defaults to https://www.strava.com/api/v3)
+      # @option options [String] :endpoint API endpoint URL (defaults to https://www.api-v3.strava.com)
       #
       def initialize(options = {})
         Strava::Webhooks::Config::ATTRIBUTES.each do |key|

--- a/lib/strava/webhooks/config.rb
+++ b/lib/strava/webhooks/config.rb
@@ -41,7 +41,7 @@ module Strava
       # @return [void]
       #
       def reset
-        self.endpoint = 'https://www.strava.com/api/v3'
+        self.endpoint = 'https://www.api-v3.strava.com'
         self.client_id = nil
         self.client_secret = nil
       end

--- a/spec/fixtures/strava/client/activity.yml
+++ b/spec/fixtures/strava/client/activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534
+    uri: https://www.api-v3.strava.com/activities/1946417534
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments.yml
+++ b/spec/fixtures/strava/client/activity_comments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments_by_10.yml
+++ b/spec/fixtures/strava/client/activity_comments_by_10.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=10
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=10
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments_by_1_limit_2.yml
+++ b/spec/fixtures/strava/client/activity_comments_by_1_limit_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:57:15 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzUyMzI5MCwiY3JlYXRlZEF0IjoxNzU2MzE5ODE5MDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzUyMzI5MCwiY3JlYXRlZEF0IjoxNzU2MzE5ODE5MDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -152,7 +152,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:57:19 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -227,7 +227,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:57:20 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments_by_3.yml
+++ b/spec/fixtures/strava/client/activity_comments_by_3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=3
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=3
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments_page_size_3_by_2.yml
+++ b/spec/fixtures/strava/client/activity_comments_page_size_3_by_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=2
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=2
     body:
       encoding: US-ASCII
       string: ''
@@ -78,7 +78,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:18:03 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=2
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_comments_per_page_3_by_2.yml
+++ b/spec/fixtures/strava/client/activity_comments_per_page_3_by_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page=1&per_page=2
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page=1&per_page=2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_kudos.yml
+++ b/spec/fixtures/strava/client/activity_kudos.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/kudos
+    uri: https://www.api-v3.strava.com/activities/15605032352/kudos
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_laps.yml
+++ b/spec/fixtures/strava/client/activity_laps.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/laps
+    uri: https://www.api-v3.strava.com/activities/15605032352/laps
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_photos.yml
+++ b/spec/fixtures/strava/client/activity_photos.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/16181809559/photos?size=5000
+    uri: https://www.api-v3.strava.com/activities/16181809559/photos?size=5000
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_ride.yml
+++ b/spec/fixtures/strava/client/activity_ride.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/7142833299
+    uri: https://www.api-v3.strava.com/activities/7142833299
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_streams.yml
+++ b/spec/fixtures/strava/client/activity_streams.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534/streams?key_by_type=true
+    uri: https://www.api-v3.strava.com/activities/1946417534/streams?key_by_type=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_with_fake_id.yml
+++ b/spec/fixtures/strava/client/activity_with_fake_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
   - request:
       method: get
-      uri: https://www.strava.com/api/v3/activities/194641753419464175341946417534
+      uri: https://www.api-v3.strava.com/activities/194641753419464175341946417534
       body:
         encoding: US-ASCII
         string: ""

--- a/spec/fixtures/strava/client/activity_with_ratelimit_exceeded.yml
+++ b/spec/fixtures/strava/client/activity_with_ratelimit_exceeded.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534
+    uri: https://www.api-v3.strava.com/activities/1946417534
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/activity_zones.yml
+++ b/spec/fixtures/strava/client/activity_zones.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534/zones
+    uri: https://www.api-v3.strava.com/activities/1946417534/zones
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_activity_comments_by_1.yml
+++ b/spec/fixtures/strava/client/all_activity_comments_by_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:07:40 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzUyMzI5MCwiY3JlYXRlZEF0IjoxNzU2MzE5ODE5MDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzUyMzI5MCwiY3JlYXRlZEF0IjoxNzU2MzE5ODE5MDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -152,7 +152,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:07:40 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''
@@ -227,7 +227,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:07:41 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=1
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_activity_comments_by_2.yml
+++ b/spec/fixtures/strava/client/all_activity_comments_by_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=2
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=2
     body:
       encoding: US-ASCII
       string: ''
@@ -78,7 +78,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:06:43 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=2
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%253D%253D&page_size=2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_activity_comments_by_3.yml
+++ b/spec/fixtures/strava/client/all_activity_comments_by_3.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=3
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=3
     body:
       encoding: US-ASCII
       string: ''
@@ -79,7 +79,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 16:07:41 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=3
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?after_cursor=eyJpZCI6MjI1Nzc4MjA5OSwiY3JlYXRlZEF0IjoxNzU2MzQxNDg0MDAwfQ%253D%253D&page_size=3
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_activity_comments_by_5.yml
+++ b/spec/fixtures/strava/client/all_activity_comments_by_5.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/15605032352/comments?page_size=5
+    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=5
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_athlete_activities.yml
+++ b/spec/fixtures/strava/client/all_athlete_activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=1
+    uri: https://www.api-v3.strava.com/athlete/activities?page=1
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:45 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=2
+    uri: https://www.api-v3.strava.com/athlete/activities?page=2
     body:
       encoding: US-ASCII
       string: ''
@@ -264,7 +264,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:46 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=3
+    uri: https://www.api-v3.strava.com/athlete/activities?page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -388,7 +388,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:49 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=4
+    uri: https://www.api-v3.strava.com/athlete/activities?page=4
     body:
       encoding: US-ASCII
       string: ''
@@ -515,7 +515,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:51 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=5
+    uri: https://www.api-v3.strava.com/athlete/activities?page=5
     body:
       encoding: US-ASCII
       string: ''
@@ -646,7 +646,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:53 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=6
+    uri: https://www.api-v3.strava.com/athlete/activities?page=6
     body:
       encoding: US-ASCII
       string: ''
@@ -776,7 +776,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:54 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=7
+    uri: https://www.api-v3.strava.com/athlete/activities?page=7
     body:
       encoding: US-ASCII
       string: ''
@@ -904,7 +904,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:55 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=8
+    uri: https://www.api-v3.strava.com/athlete/activities?page=8
     body:
       encoding: US-ASCII
       string: ''
@@ -1031,7 +1031,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:56 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=9
+    uri: https://www.api-v3.strava.com/athlete/activities?page=9
     body:
       encoding: US-ASCII
       string: ''
@@ -1161,7 +1161,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:25:57 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=10
+    uri: https://www.api-v3.strava.com/athlete/activities?page=10
     body:
       encoding: US-ASCII
       string: ''
@@ -1291,7 +1291,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:00 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=11
+    uri: https://www.api-v3.strava.com/athlete/activities?page=11
     body:
       encoding: US-ASCII
       string: ''
@@ -1423,7 +1423,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:02 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=12
+    uri: https://www.api-v3.strava.com/athlete/activities?page=12
     body:
       encoding: US-ASCII
       string: ''
@@ -1555,7 +1555,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:03 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=13
+    uri: https://www.api-v3.strava.com/athlete/activities?page=13
     body:
       encoding: US-ASCII
       string: ''
@@ -1686,7 +1686,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:04 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=14
+    uri: https://www.api-v3.strava.com/athlete/activities?page=14
     body:
       encoding: US-ASCII
       string: ''
@@ -1814,7 +1814,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:07 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=15
+    uri: https://www.api-v3.strava.com/athlete/activities?page=15
     body:
       encoding: US-ASCII
       string: ''
@@ -1947,7 +1947,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:09 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=16
+    uri: https://www.api-v3.strava.com/athlete/activities?page=16
     body:
       encoding: US-ASCII
       string: ''
@@ -2078,7 +2078,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:10 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=17
+    uri: https://www.api-v3.strava.com/athlete/activities?page=17
     body:
       encoding: US-ASCII
       string: ''
@@ -2205,7 +2205,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:12 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=18
+    uri: https://www.api-v3.strava.com/athlete/activities?page=18
     body:
       encoding: US-ASCII
       string: ''
@@ -2337,7 +2337,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:14 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=19
+    uri: https://www.api-v3.strava.com/athlete/activities?page=19
     body:
       encoding: US-ASCII
       string: ''
@@ -2469,7 +2469,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:15 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=20
+    uri: https://www.api-v3.strava.com/athlete/activities?page=20
     body:
       encoding: US-ASCII
       string: ''
@@ -2600,7 +2600,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:16 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=21
+    uri: https://www.api-v3.strava.com/athlete/activities?page=21
     body:
       encoding: US-ASCII
       string: ''
@@ -2731,7 +2731,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:19 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=22
+    uri: https://www.api-v3.strava.com/athlete/activities?page=22
     body:
       encoding: US-ASCII
       string: ''
@@ -2861,7 +2861,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:20 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=23
+    uri: https://www.api-v3.strava.com/athlete/activities?page=23
     body:
       encoding: US-ASCII
       string: ''
@@ -2987,7 +2987,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:22 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=24
+    uri: https://www.api-v3.strava.com/athlete/activities?page=24
     body:
       encoding: US-ASCII
       string: ''
@@ -3116,7 +3116,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:24 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=25
+    uri: https://www.api-v3.strava.com/athlete/activities?page=25
     body:
       encoding: US-ASCII
       string: ''
@@ -3244,7 +3244,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:25 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=26
+    uri: https://www.api-v3.strava.com/athlete/activities?page=26
     body:
       encoding: US-ASCII
       string: ''
@@ -3374,7 +3374,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:27 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=27
+    uri: https://www.api-v3.strava.com/athlete/activities?page=27
     body:
       encoding: US-ASCII
       string: ''
@@ -3504,7 +3504,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:28 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=28
+    uri: https://www.api-v3.strava.com/athlete/activities?page=28
     body:
       encoding: US-ASCII
       string: ''
@@ -3633,7 +3633,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:29 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=29
+    uri: https://www.api-v3.strava.com/athlete/activities?page=29
     body:
       encoding: US-ASCII
       string: ''
@@ -3767,7 +3767,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:30 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=30
+    uri: https://www.api-v3.strava.com/athlete/activities?page=30
     body:
       encoding: US-ASCII
       string: ''
@@ -3899,7 +3899,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:31 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=31
+    uri: https://www.api-v3.strava.com/athlete/activities?page=31
     body:
       encoding: US-ASCII
       string: ''
@@ -4032,7 +4032,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:26:32 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=32
+    uri: https://www.api-v3.strava.com/athlete/activities?page=32
     body:
       encoding: US-ASCII
       string: ''
@@ -4162,7 +4162,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:26 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=33
+    uri: https://www.api-v3.strava.com/athlete/activities?page=33
     body:
       encoding: US-ASCII
       string: ''
@@ -4288,7 +4288,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:29 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=34
+    uri: https://www.api-v3.strava.com/athlete/activities?page=34
     body:
       encoding: US-ASCII
       string: ''
@@ -4422,7 +4422,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:33 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=35
+    uri: https://www.api-v3.strava.com/athlete/activities?page=35
     body:
       encoding: US-ASCII
       string: ''
@@ -4554,7 +4554,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:34 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=36
+    uri: https://www.api-v3.strava.com/athlete/activities?page=36
     body:
       encoding: US-ASCII
       string: ''
@@ -4687,7 +4687,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:38 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=37
+    uri: https://www.api-v3.strava.com/athlete/activities?page=37
     body:
       encoding: US-ASCII
       string: ''
@@ -4818,7 +4818,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:41 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=38
+    uri: https://www.api-v3.strava.com/athlete/activities?page=38
     body:
       encoding: US-ASCII
       string: ''
@@ -4952,7 +4952,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:42 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=39
+    uri: https://www.api-v3.strava.com/athlete/activities?page=39
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_athlete_activities_by_72.yml
+++ b/spec/fixtures/strava/client/all_athlete_activities_by_72.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=1&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=1&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -212,7 +212,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:43 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=2&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=2&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -412,7 +412,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:46 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=3&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=3&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -619,7 +619,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:48 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=4&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=4&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -824,7 +824,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:51 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=5&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=5&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:53 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=6&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=6&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -1245,7 +1245,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:57 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=7&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=7&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -1453,7 +1453,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:30:59 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=8&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=8&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -1666,7 +1666,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:01 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=9&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=9&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -1875,7 +1875,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:04 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=10&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=10&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -2080,7 +2080,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:08 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=11&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=11&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -2286,7 +2286,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:10 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=12&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=12&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -2497,7 +2497,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:11 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=13&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=13&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -2710,7 +2710,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:13 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=14&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=14&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -2917,7 +2917,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:16 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=15&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=15&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -3133,7 +3133,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:18 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=16&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=16&per_page=72
     body:
       encoding: US-ASCII
       string: ''
@@ -3324,7 +3324,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2025 21:31:20 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=17&per_page=72
+    uri: https://www.api-v3.strava.com/athlete/activities?page=17&per_page=72
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_athlete_activities_latest.yml
+++ b/spec/fixtures/strava/client/all_athlete_activities_latest.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?page=1&per_page=1
+    uri: https://www.api-v3.strava.com/athlete/activities?page=1&per_page=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/all_club_activities.yml
+++ b/spec/fixtures/strava/client/all_club_activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities?page=1
+    uri: https://www.api-v3.strava.com/clubs/209437/activities?page=1
     body:
       encoding: US-ASCII
       string: ''
@@ -107,7 +107,7 @@ http_interactions:
   recorded_at: Sun, 19 Oct 2025 15:24:36 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities?page=2
+    uri: https://www.api-v3.strava.com/clubs/209437/activities?page=2
     body:
       encoding: US-ASCII
       string: ''
@@ -209,7 +209,7 @@ http_interactions:
   recorded_at: Sun, 19 Oct 2025 15:24:41 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities?page=3
+    uri: https://www.api-v3.strava.com/clubs/209437/activities?page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -312,7 +312,7 @@ http_interactions:
   recorded_at: Sun, 19 Oct 2025 15:24:45 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities?page=4
+    uri: https://www.api-v3.strava.com/clubs/209437/activities?page=4
     body:
       encoding: US-ASCII
       string: ''
@@ -391,7 +391,7 @@ http_interactions:
   recorded_at: Sun, 19 Oct 2025 15:24:49 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities?page=5
+    uri: https://www.api-v3.strava.com/clubs/209437/activities?page=5
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete.yml
+++ b/spec/fixtures/strava/client/athlete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete
+    uri: https://www.api-v3.strava.com/athlete
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_activities.yml
+++ b/spec/fixtures/strava/client/athlete_activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities
+    uri: https://www.api-v3.strava.com/athlete/activities
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_activities_december_2018.yml
+++ b/spec/fixtures/strava/client/athlete_activities_december_2018.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/activities?after=1541088000&before=1543683600
+    uri: https://www.api-v3.strava.com/athlete/activities?after=1541088000&before=1543683600
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_clubs.yml
+++ b/spec/fixtures/strava/client/athlete_clubs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/clubs
+    uri: https://www.api-v3.strava.com/athlete/clubs
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_routes.yml
+++ b/spec/fixtures/strava/client/athlete_routes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athletes/26462176/routes
+    uri: https://www.api-v3.strava.com/athletes/26462176/routes
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_stats.yml
+++ b/spec/fixtures/strava/client/athlete_stats.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athletes/26462176/stats
+    uri: https://www.api-v3.strava.com/athletes/26462176/stats
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/athlete_zones.yml
+++ b/spec/fixtures/strava/client/athlete_zones.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/athlete/zones
+    uri: https://www.api-v3.strava.com/athlete/zones
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/authorization_error.yml
+++ b/spec/fixtures/strava/client/authorization_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534
+    uri: https://www.api-v3.strava.com/activities/1946417534
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/club.yml
+++ b/spec/fixtures/strava/client/club.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/108605
+    uri: https://www.api-v3.strava.com/clubs/108605
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/club_activities.yml
+++ b/spec/fixtures/strava/client/club_activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/209437/activities
+    uri: https://www.api-v3.strava.com/clubs/209437/activities
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/club_admins.yml
+++ b/spec/fixtures/strava/client/club_admins.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/108605/admins
+    uri: https://www.api-v3.strava.com/clubs/108605/admins
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/club_events.yml
+++ b/spec/fixtures/strava/client/club_events.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/456773/group_events
+    uri: https://www.api-v3.strava.com/clubs/456773/group_events
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/club_members.yml
+++ b/spec/fixtures/strava/client/club_members.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/clubs/108605/members
+    uri: https://www.api-v3.strava.com/clubs/108605/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/create_activity.yml
+++ b/spec/fixtures/strava/client/create_activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.strava.com/api/v3/activities
+    uri: https://www.api-v3.strava.com/activities
     body:
       encoding: UTF-8
       string: commute=false&description=Test+strava-ruby-client+activity.&distance=1000&elapsed_time=1234&name=strava-ruby-client+activity&photo_ids&sport_type=Run&start_date_local=2025-10-18+19%3A04%3A26+-0400&trainer=false

--- a/spec/fixtures/strava/client/create_upload.yml
+++ b/spec/fixtures/strava/client/create_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.strava.com/api/v3/uploads
+    uri: https://www.api-v3.strava.com/uploads
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Sun, 01 Jan 2023 06:24:49 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/8919698041
+    uri: https://www.api-v3.strava.com/uploads/8919698041
     body:
       encoding: US-ASCII
       string: ''
@@ -147,7 +147,7 @@ http_interactions:
   recorded_at: Sun, 01 Jan 2023 06:24:49 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/8919698041
+    uri: https://www.api-v3.strava.com/uploads/8919698041
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/create_upload_file_processing.yml
+++ b/spec/fixtures/strava/client/create_upload_file_processing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.strava.com/api/v3/uploads
+    uri: https://www.api-v3.strava.com/uploads
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Sun, 01 Jan 2023 06:25:51 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/8919699210
+    uri: https://www.api-v3.strava.com/uploads/8919699210
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/create_upload_file_with_error.yml
+++ b/spec/fixtures/strava/client/create_upload_file_with_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.strava.com/api/v3/uploads
+    uri: https://www.api-v3.strava.com/uploads
     body:
       encoding: ASCII-8BIT
       string: !binary |-
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Sun, 01 Jan 2023 06:26:04 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/8919699501
+    uri: https://www.api-v3.strava.com/uploads/8919699501
     body:
       encoding: US-ASCII
       string: ''
@@ -147,7 +147,7 @@ http_interactions:
   recorded_at: Sun, 01 Jan 2023 06:26:05 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/8919699501
+    uri: https://www.api-v3.strava.com/uploads/8919699501
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/explore_segments.yml
+++ b/spec/fixtures/strava/client/explore_segments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/explore?activity_type=running&bounds=36.372975,-94.220234,36.415949,-94.18367
+    uri: https://www.api-v3.strava.com/segments/explore?activity_type=running&bounds=36.372975,-94.220234,36.415949,-94.18367
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/export_route_gpx.yml
+++ b/spec/fixtures/strava/client/export_route_gpx.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/routes/16341573/export_gpx
+    uri: https://www.api-v3.strava.com/routes/16341573/export_gpx
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/export_route_tcx.yml
+++ b/spec/fixtures/strava/client/export_route_tcx.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/routes/16341573/export_tcx
+    uri: https://www.api-v3.strava.com/routes/16341573/export_tcx
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/gear.yml
+++ b/spec/fixtures/strava/client/gear.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/gear/g3423618
+    uri: https://www.api-v3.strava.com/gear/g3423618
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Sun, 19 Oct 2025 15:31:22 GMT
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/gear/b16988545
+    uri: https://www.api-v3.strava.com/gear/b16988545
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/not_found_error.yml
+++ b/spec/fixtures/strava/client/not_found_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/activities/1946417534
+    uri: https://www.api-v3.strava.com/activities/1946417534
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/revoke.yml
+++ b/spec/fixtures/strava/client/revoke.yml
@@ -1,10 +1,10 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://www.api-v3.strava.com/activities/15605032352/comments?page_size=2
+    method: post
+    uri: https://www.strava.com/oauth/revoke
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
     headers:
       Authorization:
@@ -13,6 +13,8 @@ http_interactions:
       - application/json; charset=utf-8
       User-Agent:
       - Strava Ruby Client/3.0.0
+      Content-Length:
+      - '0'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -27,15 +29,15 @@ http_interactions:
       Connection:
       - keep-alive
       Date:
-      - Mon, 20 Oct 2025 16:19:48 GMT
+      - Sat, 18 Oct 2025 23:04:42 GMT
       X-Envoy-Upstream-Service-Time:
-      - '132'
+      - '75'
       Server:
       - istio-envoy
       Status:
       - 200 OK
       X-Ratelimit-Usage:
-      - '1,215'
+      - '79,222'
       X-Ratelimit-Limit:
       - '200,2000'
       Vary:
@@ -49,31 +51,29 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       X-Request-Id:
-      - bb9d8ae3-d944-47ae-94d1-95422df31a5d
+      - 06d18573-ea3e-4588-881c-2b3d3582e482
       X-Readratelimit-Limit:
       - '100,1000'
       X-Download-Options:
       - noopen
       Etag:
-      - W/"30aae7abb9e1b9801e05e9187f3e444b"
+      - W/"738cae1270cb923f543dfb09b9b75dd8"
       X-Frame-Options:
       - DENY
       X-Readratelimit-Usage:
-      - '1,215'
+      - '78,221'
       X-Content-Type-Options:
       - nosniff
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 a363b826ba48f4e79f7e95839a3bcf3a.cloudfront.net (CloudFront)
+      - 1.1 7933995c46b01504206ecd6d3dfa5d10.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - JFK52-P3
       X-Amz-Cf-Id:
-      - OH0O5MC0e3Nv_xdQ4OE4OTnIlGOtzCjVin6cy0VpSBmEiCwsOQULYw==
+      - 52HUzlAiwUhn31alTAZD1GtkGCF_tXje9lDJbTfV8xXKMD7guGwMnA==
     body:
       encoding: UTF-8
-      string: '[{"id":2257523290,"activity_id":15605032352,"post_id":null,"resource_state":2,"text":"you
-        pass?","mentions_metadata":null,"created_at":"2025-08-27T18:36:59Z","cursor":"eyJpZCI6MjI1NzUyMzI5MCwiY3JlYXRlZEF0IjoxNzU2MzE5ODE5MDAwfQ%3D%3D","athlete":{"resource_state":2,"firstname":"Sasha","lastname":"C."},"reaction_count":0,"has_reacted":false},{"id":2257703241,"activity_id":15605032352,"post_id":null,"resource_state":2,"text":"Sasha
-        Caskey I will live another day!","mentions_metadata":null,"created_at":"2025-08-27T21:55:13Z","cursor":"eyJpZCI6MjI1NzcwMzI0MSwiY3JlYXRlZEF0IjoxNzU2MzMxNzEzMDAwfQ%3D%3D","athlete":{"resource_state":2,"firstname":"Daniel","lastname":"D."},"reaction_count":1,"has_reacted":false}]'
-  recorded_at: Mon, 20 Oct 2025 16:19:48 GMT
+      string: '{"access_token":"access-token"}'
+  recorded_at: Sat, 18 Oct 2025 23:04:42 GMT
 recorded_with: VCR 6.3.1

--- a/spec/fixtures/strava/client/route.yml
+++ b/spec/fixtures/strava/client/route.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/routes/16341573
+    uri: https://www.api-v3.strava.com/routes/16341573
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment.yml
+++ b/spec/fixtures/strava/client/segment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/1109718
+    uri: https://www.api-v3.strava.com/segments/1109718
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment_effort.yml
+++ b/spec/fixtures/strava/client/segment_effort.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segment_efforts/41494197089
+    uri: https://www.api-v3.strava.com/segment_efforts/41494197089
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment_effort_streams.yml
+++ b/spec/fixtures/strava/client/segment_effort_streams.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segment_efforts/41494197089/streams?key_by_type=true
+    uri: https://www.api-v3.strava.com/segment_efforts/41494197089/streams?key_by_type=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment_efforts.yml
+++ b/spec/fixtures/strava/client/segment_efforts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/1109718/all_efforts
+    uri: https://www.api-v3.strava.com/segments/1109718/all_efforts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment_streams.yml
+++ b/spec/fixtures/strava/client/segment_streams.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/1109718/streams?key_by_type=true
+    uri: https://www.api-v3.strava.com/segments/1109718/streams?key_by_type=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/segment_streams_keys.yml
+++ b/spec/fixtures/strava/client/segment_streams_keys.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/1109718/streams?key_by_type=true&keys=distance,latlng,altitude
+    uri: https://www.api-v3.strava.com/segments/1109718/streams?key_by_type=true&keys=distance,latlng,altitude
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/starred_segments.yml
+++ b/spec/fixtures/strava/client/starred_segments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/segments/starred
+    uri: https://www.api-v3.strava.com/segments/starred
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/client/update_activity.yml
+++ b/spec/fixtures/strava/client/update_activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://www.strava.com/api/v3/activities/1982980795
+    uri: https://www.api-v3.strava.com/activities/1982980795
     body:
       encoding: UTF-8
       string: description=Updated+test+strava-ruby-client+activity.&name=updated+activity

--- a/spec/fixtures/strava/client/update_athlete.yml
+++ b/spec/fixtures/strava/client/update_athlete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://www.strava.com/api/v3/athlete
+    uri: https://www.api-v3.strava.com/athlete
     body:
       encoding: UTF-8
       string: weight=90.1

--- a/spec/fixtures/strava/client/upload.yml
+++ b/spec/fixtures/strava/client/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/uploads/2136460097
+    uri: https://www.api-v3.strava.com/uploads/2136460097
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/webhooks/create_push_subscription.yml
+++ b/spec/fixtures/strava/webhooks/create_push_subscription.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.strava.com/api/v3/push_subscriptions
+    uri: https://www.api-v3.strava.com/push_subscriptions
     body:
       encoding: UTF-8
       string: callback_url=http%3A%2F%2F35d43b4e.ngrok.io%2Fsubscribe&client_id=24523&client_secret=client-secret&verify_token=verify-token

--- a/spec/fixtures/strava/webhooks/delete_push_subscription.yml
+++ b/spec/fixtures/strava/webhooks/delete_push_subscription.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://www.strava.com/api/v3/push_subscriptions/131300?client_id=24523&client_secret=client-secret
+    uri: https://www.api-v3.strava.com/push_subscriptions/131300?client_id=24523&client_secret=client-secret
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/webhooks/no_push_subscriptions.yml
+++ b/spec/fixtures/strava/webhooks/no_push_subscriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/push_subscriptions?client_id=24523&client_secret=client-secret
+    uri: https://www.api-v3.strava.com/push_subscriptions?client_id=24523&client_secret=client-secret
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/strava/webhooks/push_subscriptions.yml
+++ b/spec/fixtures/strava/webhooks/push_subscriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.strava.com/api/v3/push_subscriptions?client_id=24523&client_secret=client-secret
+    uri: https://www.api-v3.strava.com/push_subscriptions?client_id=24523&client_secret=client-secret
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/strava/api/client/endpoints/oauth/revoke_spec.rb
+++ b/spec/strava/api/client/endpoints/oauth/revoke_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Strava::Api::Client#revoke', vcr: { cassette_name: 'client/revoke' } do
+  include_context 'with API client'
+  it 'revokes authorization' do
+    authorization = client.revoke
+    expect(authorization).to be_a Strava::Models::Authorization
+    expect(authorization.access_token).to eq 'access-token'
+  end
+end

--- a/spec/strava/api/client_spec.rb
+++ b/spec/strava/api/client_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Strava::Api::Client do
       expect { client.activity(id: 1_946_417_534) }.to raise_error Faraday::ResourceNotFound do |error|
         request = error.response[:request]
         expect(request[:method]).to eq :get
-        expect(request[:url]).to eq URI('https://www.strava.com/api/v3/activities/1946417534')
-        expect(request[:url_path]).to eq '/api/v3/activities/1946417534'
+        expect(request[:url]).to eq URI('https://www.api-v3.strava.com/activities/1946417534')
+        expect(request[:url_path]).to eq '/activities/1946417534'
       end
     end
 
@@ -65,8 +65,8 @@ RSpec.describe Strava::Api::Client do
         expect(error.ratelimit.exceeded).to eql({ fifteen_minutes_remaining: 0 })
         request = error.response[:request]
         expect(request[:method]).to eq :get
-        expect(request[:url]).to eq URI('https://www.strava.com/api/v3/activities/1946417534')
-        expect(request[:url_path]).to eq '/api/v3/activities/1946417534'
+        expect(request[:url]).to eq URI('https://www.api-v3.strava.com/activities/1946417534')
+        expect(request[:url_path]).to eq '/activities/1946417534'
       end
     end
   end

--- a/spec/strava/api/config_spec.rb
+++ b/spec/strava/api/config_spec.rb
@@ -9,7 +9,7 @@ describe Strava::Api::Config do
 
   describe '#defaults' do
     it 'sets endpoint' do
-      expect(Strava::Api.config.endpoint).to eq 'https://www.strava.com/api/v3'
+      expect(Strava::Api.config.endpoint).to eq 'https://www.api-v3.strava.com'
     end
   end
 

--- a/spec/strava/webhooks/client_spec.rb
+++ b/spec/strava/webhooks/client_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Strava::Webhooks::Client do
 
     describe '#initialize' do
       it 'sets endpoint' do
-        expect(client.endpoint).to eq 'https://www.strava.com/api/v3'
+        expect(client.endpoint).to eq 'https://www.api-v3.strava.com'
       end
 
       Strava::Webhooks::Config::ATTRIBUTES.each do |key|

--- a/spec/strava/webhooks/config_spec.rb
+++ b/spec/strava/webhooks/config_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe Strava::Webhooks::Config do
   describe '#defaults' do
     it 'sets endpoint' do
-      expect(Strava::Webhooks.config.endpoint).to eq 'https://www.strava.com/api/v3'
+      expect(Strava::Webhooks.config.endpoint).to eq 'https://www.api-v3.strava.com'
       expect(Strava::Webhooks.config.client_id).to be_nil
       expect(Strava::Webhooks.config.client_secret).to be_nil
     end
@@ -20,7 +20,7 @@ describe Strava::Webhooks::Config do
     end
 
     it 'sets client id and secret' do
-      expect(Strava::Webhooks.config.endpoint).to eq 'https://www.strava.com/api/v3'
+      expect(Strava::Webhooks.config.endpoint).to eq 'https://www.api-v3.strava.com'
       expect(Strava::Webhooks.config.client_id).to eq 'client id'
       expect(Strava::Webhooks.config.client_secret).to eq 'client secret'
     end


### PR DESCRIPTION
## Description

Strava published a [developer program update](https://communityhub.strava.com/insider-journal-9/an-update-to-our-developer-program-13428) that includes the following technical changes, effective **June 1, 2027**:

1. Authorization tokens must be sent in request headers (not form params).
2. The API base URL is changing from `https://www.strava.com/api/v3` to `https://www.api-v3.strava.com`.
3. A new `oauth/revoke` endpoint is available today; `oauth/deauthorize` will be retired on June 1, 2027.

## Changes

* **Auth header**: already compliant — `Strava::Api::Client#headers` already sends `Authorization: Bearer <token>` as an HTTP header, not as a form param. No code change was required here.
* **Base URL**: changed the default `endpoint` for `Strava::Api::Config` and `Strava::Webhooks::Config` from `https://www.strava.com/api/v3` to `https://www.api-v3.strava.com`. Updated docs/comments referencing the old URL.
* **oauth/revoke**: added `Strava::Api::Client#revoke`, which posts to the new `oauth/revoke` endpoint and returns a `Strava::Models::Authorization`, mirroring `#deauthorize`.
* **oauth/deauthorize deprecation**: added `@deprecated` doc notes pointing to `#revoke`, since `oauth/deauthorize` is retiring June 1, 2027. The method itself is unchanged/still functional.
* Updated README (new "Revoke" section, deprecation note on "Deauthorize", endpoint defaults) and CHANGELOG.
* Updated specs/fixtures (VCR cassettes) to reflect the new base URL, and added a spec + cassette for `#revoke`.

## Testing

* `bundle exec rspec` — 255 examples, 0 failures.
* `bundle exec rubocop` — no offenses.