### PR TITLE
Migrate Danger to use danger-pr-comment workflow and modernize CI

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,16 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,19 +1,11 @@
-name: PR Linter
-on: [pull_request]
+name: Danger
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 jobs:
   danger:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.danger
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-          bundler-cache: true
-      - run: |
-          # the personal token is public, this is ok, base64 encode to avoid tripping Github
-          TOKEN=$(echo -n Z2hwX0xNQ3VmanBFeTBvYkZVTWh6NVNqVFFBOEUxU25abzBqRUVuaAo= | base64 --decode)
-          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: "3.4"
+      danger-args: "dry_run --base=origin/master"

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,10 +4,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.4
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,15 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
           - "jruby-9.4"
           - "jruby-10"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.1.0 (Next)
 
 * [#100](https://github.com/dblock/strava-ruby-client/pull/100): Adds comprehensive rdoc documentation - [@dblock](https://github.com/dblock).
+* [#103](https://github.com/dblock/strava-ruby-client/pull/103): Migrate Danger to use the `danger-pr-comment` reusable workflow - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * Your contribution here.
 
 ### 3.0.0 (2025/10/24)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
 toc.check!
-changelog.check
+changelog.check!

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gemspec
 
 group :development, :test do
   gem 'csv'
+  gem 'danger-changelog', '~> 0.8.0'
+  gem 'danger-pr-comment'
+  gem 'danger-toc', '~> 0.2.0'
   gem 'dotenv'
   gem 'faraday-retry'
   gem 'gpx'

--- a/Gemfile.danger
+++ b/Gemfile.danger
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-group :test do
-  gem 'danger-changelog', '~> 0.4.2'
-  gem 'danger-toc', '~> 0.2.0', require: false
-end


### PR DESCRIPTION
Migrate Danger to use the `danger-pr-comment` reusable workflow (as in dblock/open-weather-ruby-client#49) and modernize CI (as in dblock/open-weather-ruby-client#48).

- Replace `danger.yml`'s inline `bundle exec danger` step (hardcoded/expired PAT) with a call to `numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0` (uses `GITHUB_TOKEN`).
- Add `danger-comment.yml` workflow to post PR comments on Danger completion.
- Merge `Gemfile.danger` dependencies into the main `Gemfile` (danger gems), upgrade `danger-changelog` to 0.8.0, add `danger-pr-comment`. Remove the now-unused `Gemfile.danger`.
- Import `danger-pr-comment`'s Dangerfile plugin, use `check!` instead of deprecated `check`.
- Bump `actions/checkout` v5 → v7 in all workflows.
- Test matrix: drop EOL Ruby 3.0, add Ruby 4.0.
- Bump RuboCop job's pinned Ruby from 3.0 → 3.4.
