### PR TITLE
Fix Danger Comment workflow permissions error

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  contents: read
   actions: read
   issues: write
   pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#100](https://github.com/dblock/strava-ruby-client/pull/100): Adds comprehensive rdoc documentation - [@dblock](https://github.com/dblock).
 * [#103](https://github.com/dblock/strava-ruby-client/pull/103): Migrate Danger to use the `danger-pr-comment` reusable workflow - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
+* [#104](https://github.com/dblock/strava-ruby-client/pull/104): Fixes `Danger Comment` workflow failing with a `contents: none` permissions error - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.0.0 (2025/10/24)


### PR DESCRIPTION
## Description

The `Danger Comment` workflow (triggered via `workflow_run` after the `Danger` workflow completes) was failing at startup with:

```
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

See: https://github.com/dblock/strava-ruby-client/actions/runs/32772862925 (0 jobs ran - startup_failure).

## Root Cause

The reusable `numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0` workflow declares `contents: read` in its own `permissions` block, but a caller workflow cannot grant more permissions to a called reusable workflow than it explicitly declares for itself. Our caller (`.github/workflows/danger-comment.yml`) only declared `actions: read`, `issues: write`, and `pull-requests: write`, so `contents` defaulted to `none`, causing the run to fail before any job could start.

## Fix

Add `contents: read` to the caller workflow's `permissions` block so it matches (and can grant) what the reusable workflow requires.
