### PR TITLE
Add test coverage reporting with coveralls.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,19 @@
+---
+name: Coverage
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install Ruby (3.4)
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4
+        bundler-cache: true
+    - name: Build and test with RSpec
+      run: RACK_ENV=test bundle exec rake spec
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .vscode
 Gemfile.lock
 pkg
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#104](https://github.com/dblock/strava-ruby-client/pull/104): Fixes `Danger Comment` workflow failing with a `contents: none` permissions error - [@dblock](https://github.com/dblock).
 * [#102](https://github.com/dblock/strava-ruby-client/pull/102): Changes default API base URL to `https://www.api-v3.strava.com` and adds `revoke`, deprecating `deauthorize`, per Strava's June 2026/2027 developer program changes - [@dblock](https://github.com/dblock).
 * [#105](https://github.com/dblock/strava-ruby-client/pull/105): Adds `total_elevation_gain`, `total_elevation_loss` and formatted helpers to `Strava::Models::Stream`, computed from altitude stream data - [@dblock](https://github.com/dblock).
+* [#106](https://github.com/dblock/strava-ruby-client/pull/106): Adds test coverage reporting with [coveralls.io](https://coveralls.io) - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.0.0 (2025/10/24)

--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,7 @@ group :development, :test do
   gem 'webmock'
   gem 'webrick', '~> 1.9'
 end
+
+group :test do
+  gem 'coveralls_reborn', require: false
+end

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/strava-ruby-client.svg)](https://badge.fury.io/rb/strava-ruby-client)
 [![Test](https://github.com/dblock/strava-ruby-client/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/dblock/strava-ruby-client/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/dblock/strava-ruby-client/badge.svg?branch=master)](https://coveralls.io/github/dblock/strava-ruby-client?branch=master)
 
 A complete Ruby client for the [Strava API v3](https://developers.strava.com).
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
 
 require 'rubygems'
+
+require 'coveralls'
+Coveralls.wear!
+
 require 'rspec'
 require 'strava-ruby-client'
 


### PR DESCRIPTION
## Description

Adds test coverage reporting via [coveralls.io](https://coveralls.io), inspired by [dblock/ruby-enum](https://github.com/dblock/ruby-enum).

## Changes

* Adds `coveralls_reborn` gem to the `test` group in the `Gemfile`.
* Wires up `Coveralls.wear!` in `spec/spec_helper.rb`.
* Adds a `Coverage` GitHub Actions workflow (`.github/workflows/coverage.yml`) that runs on push and reports to Coveralls using a `COVERALLS_REPO_TOKEN` secret.
* Adds a Coverage Status badge to the README.
* Ignores the local `coverage/` output directory.

## Note

This requires a `COVERALLS_REPO_TOKEN` repository secret to be configured (and the repo added on coveralls.io) for the `Coverage` workflow to successfully report results.
