### PR TITLE
Order club functions logically for user flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Unlike other clients, including [strava-api-v3](https://github.com/jaredholdcrof
     - [Get Athlete Stats](#get-athlete-stats)
     - [Update Athlete](#update-athlete)
   - [Clubs](#clubs)
-    - [List Club Events](#list-club-events)
-    - [Get Club](#get-club)
     - [List Athlete Clubs](#list-athlete-clubs)
+    - [Get Club](#get-club)
+    - [List Club Events](#list-club-events)
   - [Gears](#gears)
     - [Get Equipment](#get-equipment)
   - [Routes](#routes)
@@ -382,32 +382,6 @@ See [Strava::Models::DetailedAthlete](lib/strava/models/detailed_athlete.rb) for
 
 Strava removed the Club Activities, Club Members, and Club Admins endpoints on September 1, 2026 (see the [Strava API changelog](https://developers.strava.com/docs/changelog/)). The corresponding `club_activities`, `club_members`, and `club_admins` methods have been removed from this gem.
 
-#### List Club Events
-
-Retrieve recent Events from a specific club.
-
-```ruby
-events = client.club_events(108605) # => Array[Strava::Models::ClubEvent]
-
-event = events.first # => Strava::Models::ClubEvent
-
-event.title # => 'First Group Event Ever! Yippieh!'
-```
-
-See [Strava::Models::ClubEvent](lib/strava/models/club_event.rb) for all available properties.
-
-#### Get Club
-
-Returns a given club using its identifier.
-
-```ruby
-club = client.club(108605) # => Strava::Models::DetailedClub
-
-club.name # => 'NYRR'
-```
-
-See [Strava::Models::DetailedClub](lib/strava/models/detailed_club.rb) for all available properties.
-
 #### List Athlete Clubs
 
 Returns a list of the clubs whose membership includes the authenticated athlete.
@@ -422,6 +396,32 @@ activity.strava_url # => 'https://www.strava.com/clubs/nyrr'
 ```
 
 See [Strava::Models::SummaryClub](lib/strava/models/summary_club.rb) for all available properties.
+
+#### Get Club
+
+Returns a given club using its identifier.
+
+```ruby
+club = client.club(108605) # => Strava::Models::DetailedClub
+
+club.name # => 'NYRR'
+```
+
+See [Strava::Models::DetailedClub](lib/strava/models/detailed_club.rb) for all available properties.
+
+#### List Club Events
+
+Retrieve recent Events from a specific club.
+
+```ruby
+events = client.club_events(108605) # => Array[Strava::Models::ClubEvent]
+
+event = events.first # => Strava::Models::ClubEvent
+
+event.title # => 'First Group Event Ever! Yippieh!'
+```
+
+See [Strava::Models::ClubEvent](lib/strava/models/club_event.rb) for all available properties.
 
 ### Gears
 

--- a/lib/strava/api/endpoints/clubs.rb
+++ b/lib/strava/api/endpoints/clubs.rb
@@ -17,16 +17,15 @@ module Strava
       #
       module Clubs
         #
-        # List club / group events.
+        # List logged-in athlete clubs.
         #
-        # @param id_or_options [String, Integer, Hash] Either a club ID or a hash of options including :id
-        # @param options [Hash] Additional options (if first parameter is an ID)
-        # @option options [Integer] :page Page number
-        # @option options [Integer] :per_page Number of items per page. Defaults to 30
+        # @option options [Integer] :page
+        #   Page number.
+        # @option options [Integer] :per_page
+        #   Number of items per page. Defaults to 30.
         #
-        def club_events(id_or_options, options = {}, &block)
-          id, options = parse_args(id_or_options, options)
-          paginate "clubs/#{id}/group_events", options, Strava::Models::ClubEvent, &block
+        def athlete_clubs(options = {}, &block)
+          paginate 'athlete/clubs', options, Strava::Models::SummaryClub, &block
         end
 
         #
@@ -41,15 +40,16 @@ module Strava
         end
 
         #
-        # List logged-in athlete clubs.
+        # List club / group events.
         #
-        # @option options [Integer] :page
-        #   Page number.
-        # @option options [Integer] :per_page
-        #   Number of items per page. Defaults to 30.
+        # @param id_or_options [String, Integer, Hash] Either a club ID or a hash of options including :id
+        # @param options [Hash] Additional options (if first parameter is an ID)
+        # @option options [Integer] :page Page number
+        # @option options [Integer] :per_page Number of items per page. Defaults to 30
         #
-        def athlete_clubs(options = {}, &block)
-          paginate 'athlete/clubs', options, Strava::Models::SummaryClub, &block
+        def club_events(id_or_options, options = {}, &block)
+          id, options = parse_args(id_or_options, options)
+          paginate "clubs/#{id}/group_events", options, Strava::Models::ClubEvent, &block
         end
       end
     end


### PR DESCRIPTION
Reorders the `Clubs` API functions and README documentation to follow a more natural, incremental user flow: `athlete_clubs` (discover clubs) → `club` (get details) → `club_events` (view events), rather than the previous arbitrary ordering.